### PR TITLE
Ready for Review. Updates package to 0.0.6 and updates socketio to 1.4.5 from 0.9.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,9 @@ is based on socket.io.
 
 # Documentation
 
-TODO
+As of version 0.0.6, this module supports socketio v1.4.6 and above.
+Prior to version 0.0.6, this module only supported socketio v0.9.16 and below.
+
+Client applications (e.g., Noctua) that use post 1.0 socketio will encounter an error if they use this module prior to 0.0.6.
+
+

--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-    "name": "bbop-client-barista",
-    "version": "0.0.5",
-    "license": "BSD-3-Clause",
-    "description": "Manager for handling per-model client-to-client and server-to-client communication via Barista.",
-    "keywords": [
-        "node",
-        "npm",
-        "client",
-        "server",
-        "Gene Ontology",
-        "GO",
-        "bbop",
-        "berkeleybop",
-        "Berkeley BOP",
-        "Noctua",
-        "Minerva"
-    ],
-    "author": "SJC <sjcarbon@lbl.gov> (http://berkeleybop.org/)",
-    "homepage": "http://berkeleybop.org/",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/berkeleybop/bbop-client-barista.git"
-    },
-    "engines": {
-        "node": ">= 0.12.2",
-        "npm": ">= 2.7.4"
-    },
-    "dependencies": {
-        "bbop-core": "0.0.5",
-        "bbop-registry": "0.0.3",
-        "socket.io-client": "0.9.16",
-        "underscore": "1.8.3"
-    },
-    "devDependencies": {
-        "chai": "^2.3.0",
-        "del": "^1.1.1",
-        "gulp": "^3.8.11",
-        "gulp-bump": "^0.3.0",
-        "gulp-git": "^1.2.3",
-        "gulp-jsdoc": "^0.1.4",
-        "gulp-mocha": "^2.0.1",
-        "gulp-pandoc": "^0.2.1",
-        "gulp-rename": "^1.2.2",
-        "gulp-shell": "^0.4.2",
-        "gulp-uglify": "^1.2.0",
-        "jsdoc": "^3.3.0",
-        "jsdoc-baseline": "git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
-    },
-    "bundleDependencies": [],
-    "private": false,
-    "directories": {
-        "doc": "doc",
-        "test": "tests"
-    },
-    "main": "lib/manager.js",
-    "bugs": {
-        "url": "https://github.com/berkeleybop/bbop-client-barista/issues"
-    },
-    "scripts": {
-        "update-docs": "git checkout gh-pages && git pull && git merge master && gulp doc && git commit -a -m 'bump docs' && git push && git checkout master",
-        "test": "./node_modules/.bin/gulp test"
-    }
+  "name": "bbop-client-barista",
+  "version": "0.0.6",
+  "license": "BSD-3-Clause",
+  "description": "Manager for handling per-model client-to-client and server-to-client communication via Barista.",
+  "keywords": [
+    "node",
+    "npm",
+    "client",
+    "server",
+    "Gene Ontology",
+    "GO",
+    "bbop",
+    "berkeleybop",
+    "Berkeley BOP",
+    "Noctua",
+    "Minerva"
+  ],
+  "author": "SJC <sjcarbon@lbl.gov> (http://berkeleybop.org/)",
+  "homepage": "http://berkeleybop.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berkeleybop/bbop-client-barista.git"
+  },
+  "engines": {
+    "node": ">= 0.12.2",
+    "npm": ">= 2.7.4"
+  },
+  "dependencies": {
+    "bbop-core": "0.0.5",
+    "bbop-registry": "0.0.3",
+    "socket.io-client": "^1.4.6",
+    "underscore": "1.8.3"
+  },
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-bump": "^0.3.0",
+    "gulp-git": "^1.2.3",
+    "gulp-jsdoc": "^0.1.4",
+    "gulp-mocha": "^2.0.1",
+    "gulp-pandoc": "^0.2.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.4.2",
+    "gulp-uglify": "^1.2.0",
+    "jsdoc": "^3.3.0",
+    "jsdoc-baseline": "git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
+  },
+  "bundleDependencies": [],
+  "private": false,
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "main": "lib/manager.js",
+  "bugs": {
+    "url": "https://github.com/berkeleybop/bbop-client-barista/issues"
+  },
+  "scripts": {
+    "update-docs": "git checkout gh-pages && git pull && git merge master && gulp doc && git commit -a -m 'bump docs' && git push && git checkout master",
+    "test": "./node_modules/.bin/gulp test"
+  }
 }


### PR DESCRIPTION
For review. Not sure what happens to 0.9.16 Noctua if it tries to use 1.4.5 socketio-based bbop-client-barista. In theory the NPM versions should ensure that 'old' Noctua (pre WebPhenote) gets the 'old' socketio version.

The Noctua PR at https://github.com/geneontology/noctua/pull/307 depends upon this update of socketio.

Updates socketio to 1.4.5 from 0.9.16
